### PR TITLE
Added offsetTariffTimestamps option

### DIFF
--- a/src/N3rgy.ts
+++ b/src/N3rgy.ts
@@ -7,11 +7,13 @@ export class N3rgy extends Request {
    * Constructor
    * @param {String} authToken Test
    * @param {Object} [options] Test
-   * @param {Boolean} [options.offsetConsumptionTimes] Test
+   * @param {Boolean} [options.offsetConsumptionTimestamps] Test
+   * @param {Boolean} [options.offsetTariffTimestamps] Test
    * @param {Number} [options.maxDaysPerRequest] Test
    */
   constructor(authToken: string, options: N3rgyConfigurationOptions = {
     offsetConsumptionTimestamps: false,
+    offsetTariffTimestamps: false,
     maxDaysPerRequest: 90
   }) {
     super({ authToken, options })

--- a/src/transformers/tariffDataMergeTransform.ts
+++ b/src/transformers/tariffDataMergeTransform.ts
@@ -16,7 +16,7 @@ export function tariffDataMergeTransform(rawData: N3rgyTariff[], options?: N3rgy
 
         prices: v.prices.map((p: N3rgyPrices) => {
           return {
-            timestamp: n3rgyDateToISODate(p.timestamp),
+            timestamp: offsetTime(n3rgyDateToISODate(p.timestamp), options?.offsetTariffTimestamps),
             value: p.value
           }
         })
@@ -27,12 +27,12 @@ export function tariffDataMergeTransform(rawData: N3rgyTariff[], options?: N3rgy
   return {
     resource: rawData[0].resource,
     responseTimestamp: rawData[0].responseTimestamp,
-    start: n3rgyDateToISODate(rawData[0].start),
-    end: n3rgyDateToISODate(rawData.length > 1 ? rawData[rawData.length - 1].end : rawData[0].end),
+    start: offsetTime(n3rgyDateToISODate(rawData[0].start), options?.offsetTariffTimestamps),
+    end: offsetTime(n3rgyDateToISODate(rawData.length > 1 ? rawData[rawData.length - 1].end : rawData[0].end), options?.offsetTariffTimestamps),
     values,
     availableCacheRange: {
-      start: n3rgyDateToISODate(rawData[0].availableCacheRange.start),
-      end: n3rgyDateToISODate(rawData[0].availableCacheRange.end)
+      start: offsetTime(n3rgyDateToISODate(rawData[0].availableCacheRange.start), options?.offsetConsumptionTimestamps),
+      end: offsetTime(n3rgyDateToISODate(rawData[0].availableCacheRange.end), options?.offsetConsumptionTimestamps)
     },
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,7 @@ export interface N3rgyConfiguration {
 
 export interface N3rgyConfigurationOptions {
   offsetConsumptionTimestamps?: boolean
+  offsetTariffTimestamps?: boolean
   maxDaysPerRequest?: number
 }
 


### PR DESCRIPTION
Added an offsetTariffTimestamps option to modify tariff data timestamps in the same way that the existing offsetConsumptionTimestamps option modifies consumption data timestamps